### PR TITLE
Make the result publishable.

### DIFF
--- a/draft-birkholz-cose-tsa-tst-header-parameter.md
+++ b/draft-birkholz-cose-tsa-tst-header-parameter.md
@@ -3,12 +3,16 @@ v: 3
 
 title: 'COSE Header parameter for RFC 3161 Time-Stamp Tokens'
 abbrev: TST Header
-docname: draft-birkholz-cose-tsa-tst-header-parameter-latest
+docname: draft-ietf-cose-tsa-tst-header-parameter-latest
 area: Security
 wg: COSE
 kw: Internet-Draft
 cat: std
 stream: IETF
+
+venue:
+  github: ietf-scitt/draft-birkholz-cose-tsa-tst-header-parameter
+
 
 author:
 - name: Henk Birkholz


### PR DESCRIPTION
This makes IETF -03 publishable.
However, this breaks the CI.
The renaming has to be completed.
But where is the repo from which IETF -02 was submitted?